### PR TITLE
feat: add roll, yaw, and pause controls

### DIFF
--- a/src/control.ts
+++ b/src/control.ts
@@ -19,99 +19,104 @@ let yawVelocity = 0;
 let pitchVelocity = 0;
 const maxVelocity = 0.04;
 
-// let rollVelocity = 0;
 let planeSpeed = 0.006;
 let isPaused = false;
-let curr:any;
 
 export let turbo = 0;
+
 export function updatePlaneAxis(
   x: Vector3,
   y: Vector3,
   z: Vector3,
   planePosition: Vector3,
-  camera: PerspectiveCamera,
+  camera: PerspectiveCamera
 ) {
+  // Pause/Resume toggle using 'p' button
+  if (controls['p']) {
+    isPaused = !isPaused; // Toggle isPaused state
+    controls['p'] = false; // Reset the 'p' control to avoid repeated toggling
+  }
 
-  if(controls['p'] && isPaused===false){
-    isPaused = true;
-    planeSpeed = 0;
-    planePosition.set(curr.x, curr.y, curr.z)
+  if (isPaused) {
+    return; // Skip all updates if paused
   }
-  else if(controls['p'] && isPaused===true){
-    isPaused = false;
-    planeSpeed = 0.006
-    planeSpeed = 0;
+
+  // Gradually reduce velocities
+  rollVelocity *= 0.95;
+  pitchVelocity *= 0.95;
+  yawVelocity *= 0.95;
+
+  if (Math.abs(rollVelocity) > maxVelocity) {
+    rollVelocity = Math.sign(rollVelocity) * maxVelocity;
   }
-  else{
-    rollVelocity *= 0.95;
-    pitchVelocity *= 0.95;
-    yawVelocity *= 0.95;
-  
-    if (Math.abs(rollVelocity) > maxVelocity) {
-      rollVelocity = Math.sign(rollVelocity) * maxVelocity;
-    }
-    if (Math.abs(pitchVelocity) > maxVelocity) {
-      pitchVelocity = Math.sign(pitchVelocity) * maxVelocity;
-    }
-  
-    if(controls['q']){
-      yawVelocity += 0.0025;
-    }
-    
-    if(controls['e']){
-      yawVelocity -= 0.0025;
-    }
-  
-    if (controls['w']) {
-      pitchVelocity -= 0.0025;
-    }
-    if (controls['s']) {
-      pitchVelocity += 0.0025;
-    }
-    if (controls['a']) {
-      rollVelocity += 0.0025;
-    }
-    if (controls['d']) {
-      rollVelocity -= 0.0025;
-    }
-  
-    if (controls['r']) {
-      rollVelocity = 0;
-      pitchVelocity = 0;
-      turbo = 0;
-      x.set(1, 0, 0);
-      y.set(0, 1, 0);
-      z.set(0, 0, 1);
-      planePosition.set(0, 3, 7);
-    }
-  
-    x.applyAxisAngle(z, rollVelocity);
-    y.applyAxisAngle(z, rollVelocity);
-  
-    y.applyAxisAngle(x, pitchVelocity);
-    z.applyAxisAngle(x, pitchVelocity);
-  
-    x.applyAxisAngle(y, yawVelocity);
-    z.applyAxisAngle(y, yawVelocity);
-  
-    x.normalize();
-    y.normalize();
-    z.normalize();
-  
-    if (controls.shift) {
-      turbo += 0.025;
-    } else {
-      turbo -= 0.95;
-    }
-    turbo = Math.min(Math.max(turbo, 0), 1);
-  
-    const turboSpeed = easeOutQuad(turbo) * 0.02;
-  
-    camera.fov = 45 + turboSpeed * 900;
-    camera.updateProjectionMatrix();
-  
-    curr = planePosition.add(z.clone().multiplyScalar(-planeSpeed - turboSpeed));
-    console.log(curr)
-  } 
+  if (Math.abs(pitchVelocity) > maxVelocity) {
+    pitchVelocity = Math.sign(pitchVelocity) * maxVelocity;
+  }
+  if (Math.abs(yawVelocity) > maxVelocity){
+    yawVelocity = Math.sign(yawVelocity) * maxVelocity;
+  }
+
+  // Update velocities based on controls
+  if (controls['q']) {
+    yawVelocity += 0.0025;
+  }
+
+  if (controls['e']) {
+    yawVelocity -= 0.0025;
+  }
+
+  if (controls['w']) {
+    pitchVelocity -= 0.0025;
+  }
+  if (controls['s']) {
+    pitchVelocity += 0.0025;
+  }
+  if (controls['a']) {
+    rollVelocity += 0.0025;
+  }
+  if (controls['d']) {
+    rollVelocity -= 0.0025;
+  }
+
+  // Reset plane orientation and position
+  if (controls['r']) {
+    rollVelocity = 0;
+    pitchVelocity = 0;
+    turbo = 0;
+    x.set(1, 0, 0);
+    y.set(0, 1, 0);
+    z.set(0, 0, 1);
+    planePosition.set(0, 3, 7);
+  }
+
+  // Update orientation
+  x.applyAxisAngle(z, rollVelocity);
+  y.applyAxisAngle(z, rollVelocity);
+
+  y.applyAxisAngle(x, pitchVelocity);
+  z.applyAxisAngle(x, pitchVelocity);
+
+  x.applyAxisAngle(y, yawVelocity);
+  z.applyAxisAngle(y, yawVelocity);
+
+  x.normalize();
+  y.normalize();
+  z.normalize();
+
+  // Turbo logic
+  if (controls['shift']) {
+    turbo += 0.025;
+  } else {
+    turbo -= 0.95;
+  }
+  turbo = Math.min(Math.max(turbo, 0), 1);
+
+  const turboSpeed = easeOutQuad(turbo) * 0.02;
+
+  // Update camera field of view
+  camera.fov = 45 + turboSpeed * 900;
+  camera.updateProjectionMatrix();
+
+  // Update plane position
+  planePosition.add(z.clone().multiplyScalar(-planeSpeed - turboSpeed));
 }

--- a/src/control.ts
+++ b/src/control.ts
@@ -14,12 +14,15 @@ window.addEventListener('keyup', (e) => {
   controls[e.key.toLowerCase()] = false;
 });
 
+let rollVelocity = 0;
 let yawVelocity = 0;
 let pitchVelocity = 0;
 const maxVelocity = 0.04;
 
 // let rollVelocity = 0;
-const planeSpeed = 0.006;
+let planeSpeed = 0.006;
+let isPaused = false;
+let curr:any;
 
 export let turbo = 0;
 export function updatePlaneAxis(
@@ -29,60 +32,86 @@ export function updatePlaneAxis(
   planePosition: Vector3,
   camera: PerspectiveCamera,
 ) {
-  yawVelocity *= 0.95;
-  pitchVelocity *= 0.95;
 
-  if (Math.abs(yawVelocity) > maxVelocity) {
-    yawVelocity = Math.sign(yawVelocity) * maxVelocity;
+  if(controls['p'] && isPaused===false){
+    isPaused = true;
+    planeSpeed = 0;
+    planePosition.set(curr.x, curr.y, curr.z)
   }
-  if (Math.abs(pitchVelocity) > maxVelocity) {
-    pitchVelocity = Math.sign(pitchVelocity) * maxVelocity;
+  else if(controls['p'] && isPaused===true){
+    isPaused = false;
+    planeSpeed = 0.006
+    planeSpeed = 0;
   }
-
-  if (controls['w']) {
-    pitchVelocity -= 0.0025;
-  }
-  if (controls['s']) {
-    pitchVelocity += 0.0025;
-  }
-  if (controls['a']) {
-    yawVelocity += 0.0025;
-  }
-  if (controls['d']) {
-    yawVelocity -= 0.0025;
-  }
-
-  if (controls['r']) {
-    yawVelocity = 0;
-    pitchVelocity = 0;
-    turbo = 0;
-    x.set(1, 0, 0);
-    y.set(0, 1, 0);
-    z.set(0, 0, 1);
-    planePosition.set(0, 3, 7);
-  }
-
-  x.applyAxisAngle(z, yawVelocity);
-  y.applyAxisAngle(z, yawVelocity);
-
-  y.applyAxisAngle(x, pitchVelocity);
-  z.applyAxisAngle(x, pitchVelocity);
-
-  x.normalize();
-  y.normalize();
-  z.normalize();
-
-  if (controls.shift) {
-    turbo += 0.025;
-  } else {
-    turbo -= 0.95;
-  }
-  turbo = Math.min(Math.max(turbo, 0), 1);
-
-  const turboSpeed = easeOutQuad(turbo) * 0.02;
-
-  camera.fov = 45 + turboSpeed * 900;
-  camera.updateProjectionMatrix();
-
-  planePosition.add(z.clone().multiplyScalar(-planeSpeed - turboSpeed));
+  else{
+    rollVelocity *= 0.95;
+    pitchVelocity *= 0.95;
+    yawVelocity *= 0.95;
+  
+    if (Math.abs(rollVelocity) > maxVelocity) {
+      rollVelocity = Math.sign(rollVelocity) * maxVelocity;
+    }
+    if (Math.abs(pitchVelocity) > maxVelocity) {
+      pitchVelocity = Math.sign(pitchVelocity) * maxVelocity;
+    }
+  
+    if(controls['q']){
+      yawVelocity += 0.0025;
+    }
+    
+    if(controls['e']){
+      yawVelocity -= 0.0025;
+    }
+  
+    if (controls['w']) {
+      pitchVelocity -= 0.0025;
+    }
+    if (controls['s']) {
+      pitchVelocity += 0.0025;
+    }
+    if (controls['a']) {
+      rollVelocity += 0.0025;
+    }
+    if (controls['d']) {
+      rollVelocity -= 0.0025;
+    }
+  
+    if (controls['r']) {
+      rollVelocity = 0;
+      pitchVelocity = 0;
+      turbo = 0;
+      x.set(1, 0, 0);
+      y.set(0, 1, 0);
+      z.set(0, 0, 1);
+      planePosition.set(0, 3, 7);
+    }
+  
+    x.applyAxisAngle(z, rollVelocity);
+    y.applyAxisAngle(z, rollVelocity);
+  
+    y.applyAxisAngle(x, pitchVelocity);
+    z.applyAxisAngle(x, pitchVelocity);
+  
+    x.applyAxisAngle(y, yawVelocity);
+    z.applyAxisAngle(y, yawVelocity);
+  
+    x.normalize();
+    y.normalize();
+    z.normalize();
+  
+    if (controls.shift) {
+      turbo += 0.025;
+    } else {
+      turbo -= 0.95;
+    }
+    turbo = Math.min(Math.max(turbo, 0), 1);
+  
+    const turboSpeed = easeOutQuad(turbo) * 0.02;
+  
+    camera.fov = 45 + turboSpeed * 900;
+    camera.updateProjectionMatrix();
+  
+    curr = planePosition.add(z.clone().multiplyScalar(-planeSpeed - turboSpeed));
+    console.log(curr)
+  } 
 }


### PR DESCRIPTION
This pull request introduces several changes to the `src/control.ts` file to enhance the plane control mechanics and add new features. The most important changes include introducing a pause/resume functionality, modifications to the plane's roll and yaw controls, and improvements to the plane's update logic.

Enhancements to plane control mechanics:

* Added a `rollVelocity` variable and modified the plane's roll and yaw controls to use separate velocities for each axis. [[1]](diffhunk://#diff-6d30cfe499fc0a08e7bc7c805360ff90945500527f0a7cf0e4809ef45242d7b2R17-R66) [[2]](diffhunk://#diff-6d30cfe499fc0a08e7bc7c805360ff90945500527f0a7cf0e4809ef45242d7b2L49-R83)
* Implemented a pause/resume toggle using the 'p' key, which halts all updates when the game is paused.

Improvements to plane update logic:

* Added gradual reduction of `rollVelocity`, `pitchVelocity`, and `yawVelocity` to simulate realistic deceleration.
* Updated the plane's orientation logic to apply the correct axis angles for roll, pitch, and yaw velocities.
* Included logic to update the camera's field of view based on the turbo speed and update the plane's position accordingly.